### PR TITLE
Optimizations

### DIFF
--- a/FFXIVOpcodeWizard/FFXIVOpcodeWizard.cs
+++ b/FFXIVOpcodeWizard/FFXIVOpcodeWizard.cs
@@ -16,28 +16,24 @@ namespace FFXIVOpcodeWizard
     {
         static LinkedList<Packet> pq;
 
+        static bool readYes()
+        {
+            return Console.ReadLine().ToLower().StartsWith("y");
+        }
+
         static void Main(string[] args)
         {
-            // Network monitor type
-            TCPNetworkMonitor.NetworkMonitorType MonitorType = TCPNetworkMonitor.NetworkMonitorType.RawSocket;
-            /*StringBuilder errbuff = new StringBuilder();
-            pcap_open("", 0, 0, 0, new IntPtr(), errbuff);
-            if (errbuff.ToString() != "")
-            {
-                MonitorType = TCPNetworkMonitor.NetworkMonitorType.WinPCap;
-            }*/
-
             // Packet queue
             pq = new LinkedList<Packet>();
 
             // Get game region
-            Region region = Region.Global;
             Console.WriteLine("Are you using the Chinese game client? [y/N]");
-            string regionPrompt = Console.ReadLine();
-            if (regionPrompt.ToLower().StartsWith("y"))
-            {
-                region = Region.CN;
-            }
+            Region region = readYes() ? Region.CN : Region.Global;
+
+            Console.WriteLine("Use WinPcap instead of RawSocket? [y/N]");
+            TCPNetworkMonitor.NetworkMonitorType MonitorType = readYes() 
+                ? TCPNetworkMonitor.NetworkMonitorType.WinPCap
+                : TCPNetworkMonitor.NetworkMonitorType.RawSocket;
 
             // Initialize Machina
             FFXIVNetworkMonitor monitor = new FFXIVNetworkMonitor

--- a/FFXIVOpcodeWizard/PacketProcessors.cs
+++ b/FFXIVOpcodeWizard/PacketProcessors.cs
@@ -48,7 +48,7 @@ namespace FFXIVOpcodeWizard
                     continue;
                 }
 
-                foundPacket = ScanGeneric(pq.First(p => p.Direction == "inbound"));
+                foundPacket = ScanGeneric(pq.First.Value);
                 pq.RemoveFirst();
 
                 Debug.Print($"RECV => {foundPacket.Opcode:x} - {foundPacket.Data.Length}");
@@ -81,7 +81,7 @@ namespace FFXIVOpcodeWizard
                     continue;
                 }
 
-                foundPacket = ScanGeneric(pq.First(p => p.Direction == "outbound"));
+                foundPacket = ScanGeneric(pq.First.Value);
                 pq.RemoveFirst();
 
                 Debug.Print($"SEND => {foundPacket.Opcode:x} - {foundPacket.Data.Length}");

--- a/FFXIVOpcodeWizard/WizardProcessor.cs
+++ b/FFXIVOpcodeWizard/WizardProcessor.cs
@@ -46,10 +46,10 @@ namespace FFXIVOpcodeWizard
                 (packet, parameters) => packet.PacketSize > 300 && includeBytes(packet.Data, Encoding.UTF8.GetBytes(parameters[0])), 1);
 
             //=================
-            RegisterPacketWizard("UpdateHpMpTp", "Waiting for HP/MP update; if this doesn't complete, alter your HP or MP and allow your stats to regenerate completely.", PacketDirection.Server,
-                (packet, _) => packet.PacketSize == 48 &&
-                               BitConverter.ToUInt16(packet.Data, (int) Offsets.IpcData + 4) == 10000 &&
-                               BitConverter.ToUInt16(packet.Data, (int) Offsets.IpcData + 6) == 1000);
+            RegisterPacketWizard("UpdateHpMpTp", "Enter your max HP, then alter your HP or MP and allow your stats to regenerate completely.", PacketDirection.Server,
+                (packet, parameters) => packet.PacketSize == 48 &&
+                    BitConverter.ToUInt32(packet.Data, (int) Offsets.IpcData).ToString() == parameters[0] && // HP equals MaxHP
+                    BitConverter.ToUInt16(packet.Data, (int) Offsets.IpcData + 4) == 10000, 1); // MP equals 10000
             //=================
             RegisterPacketWizard("ClientTrigger", "Please draw your weapon.", PacketDirection.Client,
                 (packet, _) =>


### PR DESCRIPTION
This PR includes following modifications: 

1. feat: add question to set NetworkMonitorType
Allow user to set NetworkMonitorType during execution.

2. fix: "Collection was modified after the enumerator ..." error
`pq` might be changed when running `pq.First(p => p.Direction == "inbound")`. As ignored packets would be removed in the loop, there is no need to search again for the correct direction.

3. fix: fix bytes searching for multi-byte characters
Current text-searching method might be problematic for multi-byte characters (CJK characters). So a naive bytes searching function has been implemented as a replacement.

4. feat: optimize packet scaning condition for UpdateHpMpTp
TP is always 0 during my test. It would be much robuster to detect this packet by comparing the HP to MaxHP provided by user.