### PR TITLE
Reorder all the scanners

### DIFF
--- a/FFXIVOpcodeWizard.csproj
+++ b/FFXIVOpcodeWizard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>karashiiro</Authors>
     <Version>2.12.0</Version>

--- a/PacketDetection/ScannerRegistry.cs
+++ b/PacketDetection/ScannerRegistry.cs
@@ -333,11 +333,12 @@ namespace FFXIVOpcodeWizard.PacketDetection
                                BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x1C) == 284);
             //=================
             uint[] limsaLominsaFishes = new uint[] { 4869, 4870, 4776, 4871, 4872, 4874, 4876 };
-            RegisterScanner("DesynthResult", "Please desynth the fish (You can also purchase a Merlthor Goby / Lominsan Anchovy / Harbor Herring from marketboard).",
+            uint[] desynthResult = new uint[] { 5267, 5823 };
+            RegisterScanner("DesynthResult", "Please desynth the fish (You can also purchase a Merlthor Goby, Lominsan Anchovy or Harbor Herring from marketboard). If you got items other than Fine Sand and Allagan Tin Piece, please desynth again.",
                 PacketSource.Server,
                 (packet, _) => (packet.PacketSize == 104 || packet.PacketSize == 136) &&
-                               BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x08) % 1000000 == 4869 &&
-                               BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x0C) % 1000000 == 5267);
+                               inArray(limsaLominsaFishes, BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x08) % 1000000) &&
+                               inArray(desynthResult, BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x0C) % 1000000));
             //=================
             int fcRank = 0;
             RegisterScanner("FreeCompanyInfo", "Load a zone. (If you are running scanners by order, suggest teleporting to Aetheryte Plaza)",

--- a/PacketDetection/ScannerRegistry.cs
+++ b/PacketDetection/ScannerRegistry.cs
@@ -132,52 +132,6 @@ namespace FFXIVOpcodeWizard.PacketDetection
                 (packet, parameters) => packet.PacketSize == 1016 && IncludesBytes(packet.Data, Encoding.UTF8.GetBytes(parameters[0])),
                 new[] { "Please enter a nearby character's name:" });
             //=================
-            uint[] darkMatter = new uint[] { 5594, 5595, 5596, 5597, 5598, 10386, 17837, 33916 };
-            var isDarkMatter = (uint itemId) => inArray(darkMatter, itemId);
-
-            RegisterScanner("MarketBoardSearchResult", "Please click \"Catalysts\" on the market board.",
-                PacketSource.Server,
-                (packet, _) =>
-                {
-                    if (packet.PacketSize != 208) return false;
-
-                    for (var i = 0; i < 22; ++i)
-                    {
-                        var itemId = BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 8 * i);
-                        if (itemId == 0)
-                        {
-                            break;
-                        }
-
-                        if (itemId == darkMatter[6])
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                });
-            RegisterScanner("MarketBoardItemListingCount", "Please open the market board listings for any Dark Matter.",
-                PacketSource.Server,
-                (packet, _) => packet.PacketSize == 48 && 
-                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
-            RegisterScanner("MarketBoardItemListingHistory", string.Empty,
-                PacketSource.Server,
-                (packet, _) => packet.PacketSize == 1080 &&
-                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
-            RegisterScanner("MarketBoardItemListing", string.Empty,
-                PacketSource.Server,
-                (packet, _) => packet.PacketSize > 1552 &&
-                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 44)));
-            RegisterScanner("MarketBoardPurchaseHandler", "Please purchase any Dark Matter",
-                PacketSource.Client,
-                (packet, _) => packet.PacketSize == 72 &&
-                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x10)));
-            RegisterScanner("MarketBoardPurchase", string.Empty,
-                PacketSource.Server,
-                (packet, _) => packet.PacketSize == 48 &&
-                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
-            //=================
             var lightningCrystals = -1;
             RegisterScanner("ActorCast", "Please teleport to Limsa Lominsa Lower Decks.",
                 PacketSource.Server,
@@ -349,9 +303,55 @@ namespace FFXIVOpcodeWizard.PacketDetection
                     return packet.PacketSize == 112 && packet.Data[Offsets.IpcData + 45] == fcRank;
                 },
                 new[] { "Please enter your Free Company rank:" });
-            RegisterScanner("FreeCompanyDialog", "Open your Free Company window (press G)",
+            RegisterScanner("FreeCompanyDialog", "Open your Free Company window (press G or ;)",
                 PacketSource.Server,
                 (packet, _) => packet.PacketSize == 112 && packet.Data[Offsets.IpcData + 0x31] == fcRank);
+            //=================
+            uint[] darkMatter = new uint[] { 5594, 5595, 5596, 5597, 5598, 10386, 17837, 33916 };
+            var isDarkMatter = (uint itemId) => inArray(darkMatter, itemId);
+
+            RegisterScanner("MarketBoardSearchResult", "Please click \"Catalysts\" on the market board.",
+                PacketSource.Server,
+                (packet, _) =>
+                {
+                    if (packet.PacketSize != 208) return false;
+
+                    for (var i = 0; i < 22; ++i)
+                    {
+                        var itemId = BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 8 * i);
+                        if (itemId == 0)
+                        {
+                            break;
+                        }
+
+                        if (itemId == darkMatter[6])
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
+            RegisterScanner("MarketBoardItemListingCount", "Please open the market board listings for any Dark Matter.",
+                PacketSource.Server,
+                (packet, _) => packet.PacketSize == 48 &&
+                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
+            RegisterScanner("MarketBoardItemListingHistory", string.Empty,
+                PacketSource.Server,
+                (packet, _) => packet.PacketSize == 1080 &&
+                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
+            RegisterScanner("MarketBoardItemListing", string.Empty,
+                PacketSource.Server,
+                (packet, _) => packet.PacketSize > 1552 &&
+                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 44)));
+            RegisterScanner("MarketBoardPurchaseHandler", "Please purchase any Dark Matter",
+                PacketSource.Client,
+                (packet, _) => packet.PacketSize == 72 &&
+                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData + 0x10)));
+            RegisterScanner("MarketBoardPurchase", string.Empty,
+                PacketSource.Server,
+                (packet, _) => packet.PacketSize == 48 &&
+                               isDarkMatter(BitConverter.ToUInt32(packet.Data, Offsets.IpcData)));
             //=================
             const uint scannerItemId = 4850; // Honey
             RegisterScanner("UpdateInventorySlot", "Please purchase a Honey from Tradecraft Supplier (2 gil).",


### PR DESCRIPTION
Reorder all the scanners to remove extra teleports, optimize paths and acquired items. Key points are:

1. Now the wizard requires only once teleport to Limsa Lominsa.
2. Make full use of hooked fish. DesynthResult can use any hooked fish in Limsa Lominsa (which is the previous scanner)
3. You can purchase any level of Dark Matter for MarketBoard related packets in case the appointed one is too expensive.
4. Optimized path with easy-to-find vendor and npc.
![image](https://user-images.githubusercontent.com/2197479/162793992-146a1030-cb9e-4f6c-af67-32b12dc6330b.png)

