### PR TITLE
chore: update HousingWardInfo for 6.1

### DIFF
--- a/PacketDetection/ScannerRegistry.cs
+++ b/PacketDetection/ScannerRegistry.cs
@@ -199,7 +199,7 @@ namespace FFXIVOpcodeWizard.PacketDetection
             //=================
             RegisterScanner("HousingWardInfo", "Please view a housing ward from a city aetheryte/ferry.",
                 PacketSource.Server,
-                (packet, parameters) => packet.PacketSize == 2440 &&
+                (packet, parameters) => packet.PacketSize == 2448 &&
                         IncludesBytes(new ArraySegment<byte>(packet.Data, Offsets.IpcData + 16, 32).ToArray(), Encoding.UTF8.GetBytes(parameters[0])),
                 new[] { "Please enter the name of whoever owns the first house in the ward (if it's an FC, their shortname):" });
             //=================


### PR DESCRIPTION
Updates the `HousingWardInfo` packet for 6.1. The 8 bytes added to the end appear to be related to whether the ward is lottery or first-come-first-serve, and FC or personal:

`00000010 00000010 00000001 00000001` - FC, lottery
`00000010 00000010 00000010 00000010` - personal, lottery

Not sure why the 2 lower bytes are duplicated but my suspicion is that the 2 higher bytes are a purchase type enum (e.g. 1 = FCFS, 2 = lottery) and the 2 lower bytes are a bitflag for personal/FC purchases.